### PR TITLE
convert get dogs return links from object to list

### DIFF
--- a/controllers/dogs.js
+++ b/controllers/dogs.js
@@ -235,7 +235,7 @@ function getPaginationLinks(limit, offset, dogNum) {
     nextPath
   );
 
-  return { curr, prev, next };
+  return [ curr, prev, next ];
 }
 
 function getPaginationLinkObject(relation, path) {


### PR DESCRIPTION
Original returned links is an object:
```
"links": {
        "curr": {
            "rel": "current",
            "href": "http://localhost:3000/dogs?limit=9&offset=0"
        },
        "prev": {
            "rel": "prev",
            "href": "http://localhost:3000/dogs?limit=9&offset=0"
        },
        "next": {
            "rel": "next",
            "href": "http://localhost:3000/dogs?limit=9&offset=9"
        }
    }
```

Changed to a list to fit the instructor's format:
```
"links": [
        {
            "rel": "current",
            "href": "http://localhost:3000/dogs?limit=9&offset=0"
        },
        {
            "rel": "prev",
            "href": "http://localhost:3000/dogs?limit=9&offset=0"
        },
        {
            "rel": "next",
            "href": "http://localhost:3000/dogs?limit=9&offset=9"
        }
    ]
```